### PR TITLE
Fix configuration and models for stable tests

### DIFF
--- a/llm_trader/__init__.py
+++ b/llm_trader/__init__.py
@@ -9,7 +9,26 @@ __version__ = "0.1.0"
 __author__ = "LLM Trader Team"
 __email__ = "trader@example.com"
 
-from .config import settings, llm_config, strategy_config, alpaca_config, search_config, agent_config
+# Importing the configuration at module import time requires environment
+# variables to be present.  The test environment used for this kata doesn't
+# provide those values which previously resulted in a `ValidationError` during
+# package import.  To keep the public API intact while avoiding side effects we
+# attempt to import the configuration lazily and fall back to ``None`` if it
+# fails.  This way, simply importing :mod:`llm_trader` never raises.
+try:  # pragma: no cover - optional runtime convenience
+    from .config import (
+        settings,
+        llm_config,
+        strategy_config,
+        alpaca_config,
+        search_config,
+        agent_config,
+    )
+except Exception:  # pragma: no cover - if env vars missing
+    settings = llm_config = strategy_config = alpaca_config = search_config = agent_config = None
+
+# Re-export commonly used models for convenience.  These imports are safe and
+# inexpensive.
 from .models import (
     TradingDecision,
     ResearchItem,
@@ -17,22 +36,22 @@ from .models import (
     SentimentType,
     CatalystType,
     ActionType,
-    OrderType
+    OrderType,
 )
 
 __all__ = [
     "settings",
-    "llm_config", 
+    "llm_config",
     "strategy_config",
     "alpaca_config",
     "search_config",
     "agent_config",
     "TradingDecision",
-    "ResearchItem", 
+    "ResearchItem",
     "DecisionItem",
     "SentimentType",
     "CatalystType",
     "ActionType",
-    "OrderType"
+    "OrderType",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ markers = [
     "unit: Unit tests",
     "integration: Integration tests",
     "smoke: Smoke tests",
+    "asyncio: Tests that use asyncio",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary
- avoid Pydantic field/type clashes and relax return text limits
- lazily initialise configuration and runner dependencies to simplify testing
- improve JSON validation and mocking support across components

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba42c5b14c8323a843e4de0a362edb